### PR TITLE
update readme for migrate-from-v1

### DIFF
--- a/v2.0.0/migrate-from-v1/README.md
+++ b/v2.0.0/migrate-from-v1/README.md
@@ -118,3 +118,17 @@ map.addMarker({
 
 });
 ```
+
+### LatLng.toUrlValue() and LayLng.toString() return values changed
+
+In version 2 the two methods LatLng.toUrlValue(precision) and LatLng.toString(), no longer return a string in the format of "lat,lng" like Google Maps JS API, but a stringified JSON value. 
+
+```js
+
+// v1
+var strLatlng = latLng.toUrlValue();
+
+// equivalent in v2 
+var strLatlng= latLng.lat + "," + latLng.lng;
+
+```


### PR DESCRIPTION
update readme for migrate-from-v1 specifically the LatLng.toUrlValue() and LatLng.toString() changes.